### PR TITLE
Modernize plugin

### DIFF
--- a/easy-peasy-mailchimp.php
+++ b/easy-peasy-mailchimp.php
@@ -4,10 +4,10 @@ Plugin Name: Easy Peasy MailChimp Ajax Form
 Plugin URI: http://themesdepot.org
 Description: Easy Peasy MailChimp allows you to easily include an ajax powered mailchimp newsletter signup form into your website through widget or shortcode.
 Author: Alessandro Tesoro
-Version: 1.0.5
+Version: 1.0.6
 Author URI: http://alessandrotesoro.me
 Requires at least: 3.8
-Tested up to: 4.0
+Tested up to: 4.5.3
 Text Domain: easy-peasy-mailchimp
 Domain Path: /languages
 License: GPLv2 or later
@@ -45,7 +45,7 @@ class Easy_Peasy_MailChimp {
 	 * @since    1.0.0
 	 */
 	public function __construct() {
-		
+
 		// Define constants
 		define( 'EPM_VERSION', '1.0.5' );
 		define( 'EPM_SLUG', plugin_basename(__FILE__));
@@ -53,7 +53,7 @@ class Easy_Peasy_MailChimp {
 		define( 'EPM_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 
 		//Filters
-		register_activation_hook(__FILE__, array( $this,'plugin_activation_check')); 
+		register_activation_hook(__FILE__, array( $this,'plugin_activation_check'));
 
 		add_filter( "plugin_action_links_".EPM_SLUG , array( $this,'epm_add_settings_link') );
 		add_filter( 'plugin_row_meta', array( $this,'epm_plugin_row_meta'), 10, 2 );
@@ -131,7 +131,7 @@ class Easy_Peasy_MailChimp {
 		require_once EPM_PLUGIN_DIR . '/includes/shortcode.php';
 
 		// Easy Peasy Ajax Handler
-		require_once EPM_PLUGIN_DIR . '/includes/ajax.php';		
+		require_once EPM_PLUGIN_DIR . '/includes/ajax.php';
 
 	}
 
@@ -195,15 +195,15 @@ class Easy_Peasy_MailChimp {
 
 	/**
 	 * Prevents Plugin Activation if host is crap.
-	 * Yes, my darling friends, php 5.2 was deprecated in 2011 
+	 * Yes, my darling friends, php 5.2 was deprecated in 2011
 	 * Run away from your host if you're still using php 5.2
 	 * @since 1.0.4
 	 */
-	function plugin_activation_check(){ 
-        if (version_compare(PHP_VERSION, '5.3', '<')) { 
-                deactivate_plugins(basename(__FILE__)); // Deactivate ourself 
-                wp_die("Sorry, but you can't run this plugin, it requires PHP 5.3 or higher. Contact your host and request a php update."); 
-        } 
+	function plugin_activation_check(){
+        if (version_compare(PHP_VERSION, '5.3', '<')) {
+                deactivate_plugins(basename(__FILE__)); // Deactivate ourself
+                wp_die("Sorry, but you can't run this plugin, it requires PHP 5.3 or higher. Contact your host and request a php update.");
+        }
 	}
 
 }

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -6,16 +6,16 @@
  */
 
 function epm_mailchimp_submit_to_list() {
-	
+
 	global $epm_options;
 
 	//get data from our ajax() call
-	$epm_list_id = $_POST['epm_list_id'];
+	$epm_list_id = sanitize_text_field($_POST['epm_list_id']);
 	if(epm_get_option('display_name_fields')):
-	$epm_name = $_POST['epm_firstname'];
-	$epm_lastname = $_POST['epm_lastname'];
+	$epm_name = sanitize_text_field($_POST['epm_firstname']);
+	$epm_lastname = sanitize_text_field($_POST['epm_lastname']);
 	endif;
-	$epm_email = $_POST['epm_email'];
+	$epm_email = sanitize_email($_POST['epm_email']);
 	$epm_enable_validation = apply_filters( 'epm_filter_validation', 'enabled' ); //filter to disable/enable default validation messages
 	$epm_enable_success = apply_filters( 'epm_filter_success', 'enabled' ); //filter to disable/enable default success messages
 
@@ -69,7 +69,7 @@ function epm_mailchimp_submit_to_list() {
 
 	// Return String
 	die();
-	
+
 }
 add_action('wp_ajax_epm_mailchimp_submit_to_list', 'epm_mailchimp_submit_to_list');
 add_action('wp_ajax_nopriv_epm_mailchimp_submit_to_list', 'epm_mailchimp_submit_to_list');

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -26,15 +26,10 @@ function epm_mailchimp_submit_to_list() {
 		if(empty($epm_name) && epm_get_option('display_name_fields')) {
 			echo '<div class="epm-message epm-error message error"><p>'.__('Please fill in first name and last name fields.'.$epm_options['display_name_fields'],'easy-peasy-mailchimp').'</p></div>';
 		}
-		// email field is empty and is not an email
-		if(empty($epm_email) && !is_email( $epm_email )) {
+		// if email is not a valid email address
+		if(!is_email( $epm_email )) {
 			echo '<div class="epm-message epm-error message error"><p>'.__('Please add a correct email address.'.$epm_options['display_name_fields'],'easy-peasy-mailchimp').'</p></div>';
 		}
-		// email field is not empty and is not an email
-		if(!empty($epm_email) && !is_email( $epm_email )) {
-			echo '<div class="epm-message epm-error message error"><p>'.__('The email address seems to be wrong.','easy-peasy-mailchimp').'</p></div>';
-		}
-
 	}
 
 	//show success if enabled and form is correctly filled

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -78,8 +78,11 @@ add_action('wp_ajax_nopriv_epm_mailchimp_submit_to_list', 'epm_mailchimp_submit_
 /**
  * Add js ajax script to footer.
  * @since    1.0.0
+ * @since 1.0.6 wait for jquery to be loaded
  */
-function epm_mailchimp_footer_js() { ?>
+function epm_mailchimp_footer_js() {
+	if ( wp_script_is( 'jquery', 'done' ) ) :
+		?>
 <script>
 jQuery(window).load(function() {
 	jQuery('.epm-submit-chimp').click(function() {
@@ -123,5 +126,7 @@ jQuery(window).load(function() {
 	});
 });
 </script>
-<?php }
+<?php
+	endif;
+}
 add_action('wp_footer','epm_mailchimp_footer_js');

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -84,47 +84,48 @@ function epm_mailchimp_footer_js() {
 	if ( wp_script_is( 'jquery', 'done' ) ) :
 		?>
 <script>
-jQuery(window).load(function() {
-	jQuery('.epm-submit-chimp').click(function() {
+	jQuery(document).ready(function($) {
+		$('.epm-sign-up-form').on('submit', function(e) {
+			e.preventDefault();
 
-		//get form values
-		var epm_form = jQuery(this);
-		var epm_list_id = jQuery(epm_form).parent().find('#epm_list_id').val();
-		var epm_firstname = jQuery(epm_form).parent().find('#epm-first-name').val();
-		var epm_lastname = jQuery(epm_form).parent().find('#epm-last-name').val();
-		var epm_email = jQuery(epm_form).parent().find('#epm-email').val();
+			//get form values
+			var epm_form = $(this);
+			var epm_list_id = $(epm_form).parent().find('#epm_list_id').val();
+			var epm_firstname = $(epm_form).parent().find('#epm-first-name').val();
+			var epm_lastname = $(epm_form).parent().find('#epm-last-name').val();
+			var epm_email = $(epm_form).parent().find('#epm-email').val();
 
-		//change submit button text
-		var submit_wait_text = jQuery(this).data('wait-text');
-		var submit_orig_text = jQuery(this).val();
-		jQuery(this).val(submit_wait_text);
+			//change submit button text
+			var submit_wait_text = $(this).data('wait-text');
+			var submit_orig_text = $(this).val();
+			$(this).val(submit_wait_text);
 
-		jQuery.ajax({
-			type: 'POST',
-			context: this,
-			url: "<?php echo admin_url('admin-ajax.php');?>",
-			data: {
-				action: 'epm_mailchimp_submit_to_list',
-				epm_list_id: epm_list_id,
-				epm_firstname: epm_firstname,
-				epm_lastname: epm_lastname,
-				epm_email: epm_email
-			},
-			success: function(data, textStatus, XMLHttpRequest){
-				var epm_ajax_response = jQuery(data);
-				jQuery(epm_form).parent().find('.epm-message').remove(); // remove existing messages on re-submission
-				jQuery(epm_form).parent().prepend(epm_ajax_response);
-				jQuery(epm_form).val(submit_orig_text); // restore submit button text
-				<?php do_action('epm_jquery_ajax_success_event');?>
-			},
-			error: function(XMLHttpRequest, textStatus, errorThrown){
-				alert('Something Went Wrong!');
-			}
+			$.ajax({
+				type: 'POST',
+				context: this,
+				url: "<?php echo admin_url('admin-ajax.php');?>",
+				data: {
+					action: 'epm_mailchimp_submit_to_list',
+					epm_list_id: epm_list_id,
+					epm_firstname: epm_firstname,
+					epm_lastname: epm_lastname,
+					epm_email: epm_email
+				},
+				success: function(data, textStatus, XMLHttpRequest){
+					var epm_ajax_response = $(data);
+					$(epm_form).parent().find('.epm-message').remove(); // remove existing messages on re-submission
+					$(epm_form).parent().prepend(epm_ajax_response);
+					$(epm_form).val(submit_orig_text); // restore submit button text
+					<?php do_action('epm_jquery_ajax_success_event');?>
+				},
+				error: function(XMLHttpRequest, textStatus, errorThrown){
+					alert(<?php __('Something Went Wrong!', 'easy-peasy-mailchimp'); ?>);
+				}
+			});
+			return false;
+
 		});
-		return false;
-
 	});
-});
 </script>
 <?php
 	endif;

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -46,14 +46,17 @@ function epm_mailchimp_submit_to_list() {
 			'send_welcome'      => (epm_get_option('send_welcome_message') ? true : false),
 		));
 
-		if(epm_get_option('display_name_fields') && !empty($epm_name) && !empty($epm_lastname) && !empty($epm_email) && is_email( $epm_email ) ) {
-			echo '<div class="epm-message epm-success message success"><p>'.__('Thank you for signing up to the newsletter.','easy-peasy-mailchimp').'</p></div>';
+		// check if the result from MailChimp is clean
+		if ($result) {
+			echo '<div class="epm-message epm-success message success">';
+			printf('<p>%s</p>', __('Thank you for signing up to the newsletter.','easy-peasy-mailchimp'));
+			if (epm_get_option('enable_double_optin')) {
+				printf('<p>%s</p>', __('Please check your email.', 'easy-peasy-mailchimp'));
+			}
+			echo '</div>';
+		} else {
+			$errors[] = __('There has been an error with MailChimp. Please contact the administrator of this website.', 'easy-peasy-mailchimp');
 		}
-
-		if(!epm_get_option('display_name_fields') && !empty($epm_email) && is_email( $epm_email )) {
-			echo '<div class="epm-message epm-success message success"><p>'.__('Thank you for signing up to the newsletter.','easy-peasy-mailchimp').'</p></div>';
-		}
-
 	}
 
 	// If there are errors output them to the user

--- a/readme.txt
+++ b/readme.txt
@@ -1,18 +1,18 @@
 === Easy Peasy MailChimp Ajax Form ===
-Contributors: alessandro.tesoro
+Contributors: alessandro.tesoro, alpipego
 Tags: email, mailchimp, marketing, newsletter, plugin, signup, MailChimp form, MailChimp Newsletter form, MailChimp plugin, ajax mailchimp, mailchimp ajax form
 Requires at least: 3.8
-Tested up to: 4.1
-Stable tag: 1.0.5
+Tested up to: 4.5.3
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 The Easy Peasy MailChimp plugin allows you to easily add an ajax powered MailChimp newsletter subscribe form in any page of your WordPress site.
 
 == Description ==
-The Easy Peasy MailChimp plugin allows you to easily add an ajax powered MailChimp newsletter subscribe form in any page of your WordPress site. You can add forms to posts or pages with a shortcode or to template files with PHP tags. Simply copy and paste your MailChimp API Key and list ID into the plugin admin settings and you're good to go. 
+The Easy Peasy MailChimp plugin allows you to easily add an ajax powered MailChimp newsletter subscribe form in any page of your WordPress site. You can add forms to posts or pages with a shortcode or to template files with PHP tags. Simply copy and paste your MailChimp API Key and list ID into the plugin admin settings and you're good to go.
 
-Using some fancy Ajax technology your users can sign up without the page refreshing, making the process fast, and unobtrusive to the browsing experience. The form also comes with plenty of css selectors that allow you to customize the layout of the signup form. 
+Using some fancy Ajax technology your users can sign up without the page refreshing, making the process fast, and unobtrusive to the browsing experience. The form also comes with plenty of css selectors that allow you to customize the layout of the signup form.
 
 In addition, the plugin comes with an intelligent templating system that allow you to easily customize the markup of the form if you need to, read the faq section for more information.
 
@@ -32,7 +32,7 @@ After Installation, the setup page will guide you through entering your API key 
 > [Free WordPress plugins](http://profiles.wordpress.org/alessandrotesoro/) | [Premium WordPress Themes](http://themeforest.net/user/ThemesDepot/portfolio) | [Follow Me On Twitter](https://twitter.com/themesdepot)
 
 == Installation ==
-1. Upload "easy-peasy-mailchimp" folder to the "/wp-content/plugins/" directory. 
+1. Upload "easy-peasy-mailchimp" folder to the "/wp-content/plugins/" directory.
 1. Activate the plugin through the "Plugins" menu in WordPress.
 1. Navigate to "Settings" -> "MailChimp Settings" of your WordPress admin panel.
 1. Enter your MailChimp settings.
@@ -56,7 +56,7 @@ Use the following shortcode to display a form anywhere you want
 1. Open your custom theme folder and create an empty folder and call it "epm" (without quotes)
 1. Navigate to folder wp-content/plugins/easy-peasy-mailchimp/templates
 1. Copy file mailchimp-form.php
-1. Paste the file into the "epm" subfolder that you created into your theme folder 
+1. Paste the file into the "epm" subfolder that you created into your theme folder
 
 = How can i disable the validation error message? =
 If you wish to disable the validation message, add the following code into your theme's function.php file
@@ -80,10 +80,10 @@ add_filter('epm_filter_success', 'epm_disable_success_message');`
 
 == Changelog ==
 = 1.0.5 =
-* Fixed: php notices displaying when debug mode enabled.  
+* Fixed: php notices displaying when debug mode enabled.
 
 = 1.0.4 =
-* Added: plugin will not activate if your web host is living in the stone age. Plugin requires PHP 5.3 or greater to work.  
+* Added: plugin will not activate if your web host is living in the stone age. Plugin requires PHP 5.3 or greater to work.
 
 = 1.0.3 =
 * Added: Ability to display multiple forms in the same page.

--- a/templates/mailchimp-form.php
+++ b/templates/mailchimp-form.php
@@ -4,10 +4,10 @@
  * @since    1.0.0
  */
 
-global $epm_options;
-
 $current_user = wp_get_current_user();
 $epm_default_email_value = null;
+$list = epm_get_option('mailchimp_list_id');
+
 if(is_user_logged_in()) {
 	$epm_default_email_value = $current_user->user_email;
 }
@@ -20,7 +20,7 @@ if(is_user_logged_in()) {
 
 	<div class="epm-form-field">
 		<label for="epm-first-name"><?php _e('First Name','easy-peasy-mailchimp');?></label>
-		<input type="text" placeholder="<?php _e('First Name','easy-peasy-mailchimp');?>" name="epm-first-name" tabindex="7" class="name first-name" id="epm-first-name"/>
+		<input type="text" placeholder="<?php _e('First Name','easy-peasy-mailchimp');?>" name="epm-first-name" tabindex="7" class="name first-name" id="epm-first-name" required />
 	</div>
 
 	<div class="epm-form-field">
@@ -32,7 +32,7 @@ if(is_user_logged_in()) {
 
 	<div class="epm-form-field">
 		<label for="epm-email"><?php _e('Email Address','easy-peasy-mailchimp');?></label>
-		<input type="email" placeholder="<?php _e('Email Address','easy-peasy-mailchimp');?>" name="epm-email" tabindex="8" class="email" id="epm-email" value="<?php echo $epm_default_email_value; ?>"/>
+		<input type="email" placeholder="<?php _e('Email Address','easy-peasy-mailchimp');?>" name="epm-email" tabindex="8" class="email" id="epm-email" value="<?php echo $epm_default_email_value; ?>" required />
 	</div>
 
 	<input type="hidden" name="epm_submit" id="epm_submit" value="true" />

--- a/templates/mailchimp-form.php
+++ b/templates/mailchimp-form.php
@@ -1,12 +1,12 @@
-<?php 
+<?php
 /**
  * Template file to display the mailchimp form
  * @since    1.0.0
  */
 
-global $epm_options, $current_user;
+global $epm_options;
 
-get_currentuserinfo();
+$current_user = wp_get_current_user();
 $epm_default_email_value = null;
 if(is_user_logged_in()) {
 	$epm_default_email_value = $current_user->user_email;
@@ -37,7 +37,7 @@ if(is_user_logged_in()) {
 
 	<input type="hidden" name="epm_submit" id="epm_submit" value="true" />
 	<input type="hidden" name="epm_list_id" id="epm_list_id" value="<?php echo $list;?>" />
-	
+
 	<input type="submit" name="epm-submit-chimp" value="<?php _e('Sign Up Now','easy-peasy-mailchimp');?>" data-wait-text="<?php _e('Please wait...','easy-peasy-mailchimp');?>" tabindex="10" class="button btn epm-sign-up-button epm-submit-chimp"/>
 
 </form>


### PR DESCRIPTION
When trying this plugin I first saw the deprecated function notice and while looking at the code, realized a couple of things were off (data sanitization and jQuery event). 

Although I have changed a couple of things, this should not be breaking anything but enhance the following parts:

* changes deprecated `get_currentuserinfo()` to `wp_get_current_user()`
* use html5 form attributes and make required fields required, remove global options from template
* sanitize $_POST data in ajax call
* simplifies email address error check, error and success handling and accounts for mailchimp api errors (in ajax callback)
* change listened event from button click to form submit 
* wait for jquery to be loaded (while still inlining script)

I have updated the readme and file header for 1.0.6 and added me as contributer.
